### PR TITLE
maint(dependabot): bundle otel deps into one commit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,8 @@ updates:
     commit-message:
       prefix: "maint"
       include: "scope"
+    groups:
+      opentelemetry:
+        patterns:
+          - "go.opentelemetry.io/*"
+          - "github.com/honeycombio/otel-config-go"


### PR DESCRIPTION
## Which problem is this PR solving?

- Dependabot wants to update our deps 1 at a time, but they need to be bundled together.

## Short description of the changes

- Updates dependabot.yml

