### PR TITLE
maint(dependabot): explicitly enumerate otel deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,5 +19,6 @@ updates:
     groups:
       opentelemetry:
         patterns:
-          - "go.opentelemetry.io/*"
+          - "go.opentelemetry.io/otel"
+          - "go.opentelemetry.io/otel/trace"
           - "github.com/honeycombio/otel-config-go"


### PR DESCRIPTION
for some reason wildcard search didn't work in #21.