### PR TITLE
fix(url): fix setting default port 4317

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 	"os/signal"
@@ -83,7 +84,7 @@ func parseHost(log Logger, host string, insecure bool) *url.URL {
 	}
 	port := u.Port()
 	if port == "" {
-		port = "4317" // default GRPC port
+		u.Host = fmt.Sprintf("%s:4317", u.Host) // default GRPC port
 	}
 	return u
 }


### PR DESCRIPTION
## Which problem is this PR solving?
- previously the local port was being set, but the url was not updated

## Short description of the changes
- Correctly defaults to using grpc port 4317 if no port specified.

