### PR TITLE
feat(generator): convert tail recursion to for loop

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -64,7 +64,7 @@ type generationState struct {
 }
 
 // generate_spans generates a list of spans with the given depth and spancount
-// it is recursive and expects spans[0] to be the root span
+// it was recursive, but has been converted from tail recursion to a loop.
 // - level is the current depth of this span where 0 is the root span
 // - depth is the maximum depth (nesting level) of a trace -- how much deeper this trace will go
 // - nspans is the number of spans in a trace.


### PR DESCRIPTION
## Which problem is this PR solving?
- We spend a lot of time managing the go runtime stack and tail recursing.

## Short description of the changes
- Manually handle our stack instead.

```
$ ./loadgen --depth=10 --extra=10 --loglevel=info --nspans=50 --sender=dummy --tps=5000 --tracecount=-1 --tracetime=30s --debugport=6060
host: https://api.honeycomb.io:443, dataset: loadgen, apikey: ...    
ngenerators: 150000.000000 interval: 6µs
all generators started, switching to Running state
^C
shutting down from operating system signal
stopping generators from stop signal
trace counter exiting after 864856 traces
sender sent 864855 traces with 54853738 spans
$ python
Python 3.10.12 (main, Nov 20 2023, 15:14:05) [GCC 11.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> 54853738/864855.
63.42535800798978
```