### PR TITLE
fix(generator): do not share fielders between goroutines

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -26,29 +26,29 @@ const (
 )
 
 type TraceGenerator struct {
-	depth    int
-	nspans   int
-	duration time.Duration
-	fielder  func() *Fielder
-	chans    []chan struct{}
-	mut      sync.RWMutex
-	log      Logger
-	tracer   Sender
+	depth      int
+	nspans     int
+	duration   time.Duration
+	getFielder func() *Fielder
+	chans      []chan struct{}
+	mut        sync.RWMutex
+	log        Logger
+	tracer     Sender
 }
 
 // make sure it implements Generator
 var _ Generator = (*TraceGenerator)(nil)
 
-func NewTraceGenerator(tsender Sender, fielder func() *Fielder, log Logger, opts Options) *TraceGenerator {
+func NewTraceGenerator(tsender Sender, getFielder func() *Fielder, log Logger, opts Options) *TraceGenerator {
 	chans := make([]chan struct{}, 0)
 	return &TraceGenerator{
-		depth:    opts.Format.Depth,
-		nspans:   opts.Format.NSpans,
-		duration: opts.Format.TraceTime,
-		fielder:  fielder,
-		chans:    chans,
-		log:      log,
-		tracer:   tsender,
+		depth:      opts.Format.Depth,
+		nspans:     opts.Format.NSpans,
+		duration:   opts.Format.TraceTime,
+		getFielder: getFielder,
+		chans:      chans,
+		log:        log,
+		tracer:     tsender,
 	}
 }
 
@@ -127,7 +127,7 @@ func (s *TraceGenerator) generator(wg *sync.WaitGroup, counter chan int64) {
 	s.mut.Unlock()
 
 	ticker := time.NewTicker(duration)
-	fielder := s.fielder()
+	fielder := s.getFielder()
 	defer wg.Done()
 	for {
 		select {

--- a/main.go
+++ b/main.go
@@ -159,12 +159,12 @@ func main() {
 
 	log := NewLogger(opts.DebugLevel())
 
-	fielder := func() *Fielder {
-		fielder, err := NewFielder(opts.Seed, args, opts.Format.Extra, opts.Format.Depth)
+	getFielderFn := func() *Fielder {
+		getFielder, err := NewFielder(opts.Seed, args, opts.Format.Extra, opts.Format.Depth)
 		if err != nil {
 			log.Fatal("unable to create fields as specified: %s\n", err)
 		}
-		return fielder
+		return getFielder
 	}
 
 	opts.apihost = parseHost(log, opts.Telemetry.Host, opts.Telemetry.Insecure)
@@ -220,7 +220,7 @@ func main() {
 	}()
 
 	// start the load generator to create spans and send them on the source chan
-	var generator Generator = NewTraceGenerator(sender, fielder, log, opts)
+	var generator Generator = NewTraceGenerator(sender, getFielderFn, log, opts)
 	wg.Add(1)
 	go generator.Generate(opts, wg, stop, counterChan)
 


### PR DESCRIPTION
## Which problem is this PR solving?

- #38 is caused by sharing of the same `*Fielder` between all goroutines. `random.RNG` is not safe to share without locking, but locking would be prohibitively expensive for us.

## Short description of the changes

- Prevents crash under extremely high TPS loads where many generator goroutines are running. Fixes #38.

