### PR TITLE
feat: Allow for adjustable boolean probability

### DIFF
--- a/fielder.go
+++ b/fielder.go
@@ -121,8 +121,8 @@ func (r Rng) WordPair() string {
 	return r.Choice(adjectives) + "-" + r.Choice(nouns)
 }
 
-func (r Rng) BoolWithProb(p int) bool {
-	return r.Int(0, 100) < int64(p)
+func (r Rng) BoolWithProb(p float64) bool {
+	return r.Float(0, 100) < p
 }
 
 // getProcessID returns the process ID
@@ -201,10 +201,10 @@ func parseUserFields(rng Rng, userfields []string) (map[string]func() any, error
 				return nil, fmt.Errorf("invalid float in user field %s: %w", field, err)
 			}
 		case "b":
-			n := 50
+			n := 50.0
 			var err error
 			if p1 != "" {
-				n, err = strconv.Atoi(p1)
+				n, err = strconv.ParseFloat(p1, 64)
 				if err != nil || n < 0 || n > 100 {
 					return nil, fmt.Errorf("invalid bool option in %s", field)
 				}

--- a/main.go
+++ b/main.go
@@ -121,7 +121,7 @@ func main() {
 		- /sq4 -- pronounceable words with cardinality 4 with quadratic distribution
 		- /ir100 -- int in a range of 0 to 100
 		- /fg50,30 -- float in a gaussian distribution with mean 50 and stddev 30
-		- /b -- boolean, true or false
+		- /b33.3 -- boolean, true or false -- probability of true is 33.3% (default 50%)
 		- /u -- https url-like, no query string, two path segments; default cardinality is 10/10 but can be changed like /u3,20
 		- /uq -- as /u above, but with query string containing a random key word with a completely random value
 		- /st -- an http status code by default reflecting 95% 200s, 4% 400s, 1% 500s. 400s and 500s can be changed like /st10,0.1.


### PR DESCRIPTION
## Which problem is this PR solving?

- Sometimes you don't want a bool to be a coinflip. This allows specifying the probability of truth.

## Short description of the changes

- Add optional probability of truth, default to 50%.

