### PR TITLE
chore(ci): match released tag to ghcr image tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: '^1.21.5'
+          go-version: '^1.21.6'
       - uses: actions/checkout@v4
       - uses: ko-build/setup-ko@v0.6
-      - run: ko build -B --platform=linux/amd64,linux/arm64
+      - run: ko build -B --platform=linux/amd64,linux/arm64 -t latest,${{github.ref_name}}


### PR DESCRIPTION
## Short description of the changes

- Automatically tags released images in ghcr with correct tag from git. Fixes #45.
