### PR TITLE
fix: support . in field names

### DIFF
--- a/fielder.go
+++ b/fielder.go
@@ -51,7 +51,7 @@ var nouns = []string{
 	"watch", "wheel", "whip", "whistle", "window", "wing", "wire", "worm",
 }
 
-var constpat = regexp.MustCompile(`^([a-zA-Z0-9_]+)=([^/].*)$`)
+var constpat = regexp.MustCompile(`^([a-zA-Z0-9_.]+)=([^/].*)$`)
 var genpat = regexp.MustCompile(`^((?:[0-9]+\.)?[a-zA-Z0-9_]+)=/([ibfsu][awxrgqt]?)([0-9.-]+)?(,[0-9.-]+)?$`)
 var keypat = regexp.MustCompile(`^([0-9]+)\.(.*$)`)
 


### PR DESCRIPTION
## Which problem is this PR solving?

- #53 

## Short description of the changes

- This adds `.` to the list of characters to match in the `constpat` regex. This should allow field names to contain dots, allowing us to make more realistic trace data: `http.status_code=/st10,0.1`, and `http.route=/u` and the like.

Fixes #53 
