### PR TITLE
maint: Update install command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ You should have a recent version of Go installed.
 
 Install:
 ```bash
-go install github.com/honeycombio/loadgen
+go install github.com/honeycombio/loadgen@latest
 ```
 
 Get Usage information:


### PR DESCRIPTION
## Which problem is this PR solving?

Updates install command in README. Without a version suffix, loadgen fails to install.

- Closes #57 

## Short description of the changes
- Add `@latest` suffix to install command