### PR TITLE
feat: Add key cardinality testing feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ more than one.
 | sw | pronounceable words, rectangular distribution | cardinality (16)||
 | sq | pronounceable words, quadratic distribution | cardinality (16) ||
 | sx | hexadecimal string | length in chars (16)||
+| k  | key fields used for testing intermittent key cardinality | cardinality (50) | period (60) |
 | u | url-like (2 parts) | cardinality of 1st part (3) | cardinality of 2nd part (10) |
 | uq | url with random query | cardinality of 1st part (3) | cardinality of 2nd part (10) |
 | st | status code | percentage of 400s | percentage of 500s |
@@ -161,6 +162,7 @@ where `0` means the root span.
 	* 1.name=/sq9 -- name is words with cardinality 9, only on spans that are direct children of the root span
 	* url=/u10,10 -- simulate URLs for 10 services, each of which has 10 endpoints
 	* status=/st10,0.1 -- generate status codes where 10% are 400s and .1% are 500s
+	* samplekey=/k50,60 -- generate sample keys with cardinality 50 but not all keys will occur before 60s
 
 ## Motivation
 

--- a/fielder_test.go
+++ b/fielder_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func Test_PeriodicEligibility_checkEligible(t *testing.T) {
+	words := strings.Split("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz", "")
+	notFound := map[string]struct{}{}
+	for _, w := range words {
+		notFound[w] = struct{}{}
+	}
+
+	pe := newPeriodicEligibility(NewRng("hello"), words, 60*time.Second)
+	t.Run("only some words show up for short period", func(t *testing.T) {
+		for i := 0; i < 100; i++ {
+			for p := 0; p < 30; p++ {
+				word := pe.getEligibleWord(time.Duration(p) * time.Second)
+				delete(notFound, word)
+			}
+			if len(notFound) == 0 {
+				break
+			}
+		}
+		if len(notFound) != 0 {
+			t.Errorf("expected some words to be not found, got none")
+		}
+	})
+
+	t.Run("all eligible words show up with full period", func(t *testing.T) {
+		for i := 0; i < 100; i++ {
+			for p := 0; p < 60; p++ {
+				word := pe.getEligibleWord(time.Duration(p) * time.Second)
+				delete(notFound, word)
+			}
+			if len(notFound) == 0 {
+				break
+			}
+		}
+		if len(notFound) > 0 {
+			t.Errorf("expected all words to be found, got %v", notFound)
+		}
+	})
+}
+
+func BenchmarkPeriodicEligibility(b *testing.B) {
+	for _, card := range []int{10, 50, 200} {
+		var words []string
+		for i := 0; i < card; i++ {
+			words = append(words, strconv.Itoa(i))
+		}
+		period := 61 * time.Second
+		pe := newPeriodicEligibility(NewRng("hello"), words, period)
+		for p := 0; p < 61; p += 10 {
+			b.Run(fmt.Sprintf("card_%02d_p_%02d", card, p), func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					pe.getEligibleWord(time.Duration(p) * time.Second)
+				}
+			})
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -159,7 +159,7 @@ func main() {
 	You can specify fields to be added to each span. Each field should be specified as
 	FIELD=VALUE. The value can be a constant (and will be sent as the appropriate type),
 	or a generator function starting with /.
-	Allowed generators are /i, /ir, /ig, /f, /fr, /fg, /s, /sx, /sw, /b, optionally
+	Allowed generators are /i, /ir, /ig, /f, /fr, /fg, /s, /sx, /sw, /b, /k, optionally
 	followed by a single number or a comma-separated pair of numbers.
 	Example generators:
 		- /s -- alphanumeric string of length 16
@@ -172,6 +172,7 @@ func main() {
 		- /u -- https url-like, no query string, two path segments; default cardinality is 10/10 but can be changed like /u3,20
 		- /uq -- as /u above, but with query string containing a random key word with a completely random value
 		- /st -- an http status code by default reflecting 95% 200s, 4% 400s, 1% 500s. 400s and 500s can be changed like /st10,0.1.
+		- /k50,60 -- an intermittent key field with total cardinality 50, but decreasing key frequency. All keys only arrive after 60 seconds
 
 	Field names can be alphanumeric with underscores. If a field name is prefixed with
 	a number and a dot (e.g. 1.foo=bar) the field will only be injected into spans at


### PR DESCRIPTION
## Which problem is this PR solving?

- We've seen issues where the key cardinality of things being fed to a sampler is longer than the sampler AdjustmentInterval. This gives loadgen the ability to generate fields that will only include all possible values once the generator's sample period has completed. 

So `mykey=/k50,60` will generate a field called mykey that will have values of cardinality 50, but not all possible values will be used until 60 seconds have passed. 

Includes testing and benchmark code, as well as a readme update.