### PR TITLE
feat(otlp): Add ability to produce traces with multiple services.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,8 @@
 module github.com/honeycombio/loadgen
 
-go 1.21
-toolchain go1.22.5
+go 1.22.0
+
+toolchain go1.23.1
 
 require (
 	github.com/dgryski/go-wyhash v0.0.0-20191203203029-c4841ae36371

--- a/sample_config.yaml
+++ b/sample_config.yaml
@@ -3,22 +3,31 @@
 # Note that you must specify HONEYCOMB_API_KEY in your environment
 # or --apikey on the command line to authenticate with Honeycomb.
 telemetry:
-    dataset: my-dataset
+  host: "api.honeycomb.io:443"
+  services:
+    - "stargate"
+    - "apollo"
+    - "gemini"
+    - "mercury"
+    - "artemis"
+    - "pioneer"
+    - "frontiers"
 format:
-    depth: 5
-    nspans: 100
-    tracetime: 10s
+  depth: 6
+  nspans: 100
+  tracetime: 5s
 quantity:
-    tps: 1
-    tracecount: 2
-    ramptime: 1s
+  tps: 100
+  tracecount: 2000
+  ramptime: 1s
 output:
-    sender: honeycomb
-    protocol: grpc
+  sender: otel
+  protocol: grpc
 global:
-    loglevel: warn
+  loglevel: warn
 fields:
-    # simulate URLs for 10 services, each of which has 10 endpoints
-	http.url: /u10,10
+  # simulate URLs for 10 services, each of which has 10 endpoints
+  http.url:
+    /u10,10
     # generate status codes where 10% are 400s and .1% are 500s
-	http.status: /st10,0.1
+  http.status: /st10,0.1

--- a/sender.go
+++ b/sender.go
@@ -30,7 +30,7 @@ type Sendable interface {
 }
 
 type Sender interface {
-	CreateTrace(ctx context.Context, name string, fielder *Fielder, count int64) (context.Context, Sendable)
-	CreateSpan(ctx context.Context, name string, level int, fielder *Fielder) (context.Context, Sendable)
+	CreateTrace(ctx context.Context, name string, service string, fielder *Fielder, count int64) (context.Context, Sendable)
+	CreateSpan(ctx context.Context, name string, service string, level int, fielder *Fielder) (context.Context, Sendable)
 	Close()
 }

--- a/sender_dummy.go
+++ b/sender_dummy.go
@@ -60,13 +60,13 @@ func (t *SenderDummy) Close() {
 	t.log.Warn("sender sent %d traces with %d spans\n", t.tracecount, t.nspans)
 }
 
-func (t *SenderDummy) CreateTrace(ctx context.Context, name string, fielder *Fielder, count int64) (context.Context, Sendable) {
+func (t *SenderDummy) CreateTrace(ctx context.Context, name string, service string, fielder *Fielder, count int64) (context.Context, Sendable) {
 	t.tracecount++
 	t.nspans++
 	return ctx, DummySendable{}
 }
 
-func (t *SenderDummy) CreateSpan(ctx context.Context, name string, level int, fielder *Fielder) (context.Context, Sendable) {
+func (t *SenderDummy) CreateSpan(ctx context.Context, name string, service string, level int, fielder *Fielder) (context.Context, Sendable) {
 	t.nspans++
 	return ctx, DummySendable{}
 }

--- a/sender_honeycomb.go
+++ b/sender_honeycomb.go
@@ -25,7 +25,7 @@ func (t *SenderHoneycomb) Close() {
 	beeline.Close()
 }
 
-func (t *SenderHoneycomb) CreateTrace(ctx context.Context, name string, fielder *Fielder, count int64) (context.Context, Sendable) {
+func (t *SenderHoneycomb) CreateTrace(ctx context.Context, name string, service string, fielder *Fielder, count int64) (context.Context, Sendable) {
 	// a beeline span is already a Sendable
 	ctx, root := beeline.StartSpan(ctx, name)
 	for k, v := range fielder.GetFields(count, 0) {
@@ -34,7 +34,7 @@ func (t *SenderHoneycomb) CreateTrace(ctx context.Context, name string, fielder 
 	return ctx, root
 }
 
-func (t *SenderHoneycomb) CreateSpan(ctx context.Context, name string, level int, fielder *Fielder) (context.Context, Sendable) {
+func (t *SenderHoneycomb) CreateSpan(ctx context.Context, name string, service string, level int, fielder *Fielder) (context.Context, Sendable) {
 	// a beeline span is already a Sendable
 	ctx, span := beeline.StartSpan(ctx, name)
 	for k, v := range fielder.GetFields(0, level) {

--- a/sender_otel_honey.go
+++ b/sender_otel_honey.go
@@ -24,7 +24,7 @@ func (s OTelSendable) Send() {
 }
 
 type SenderOTel struct {
-	tracer   trace.Tracer
+	tracers  map[string]trace.Tracer
 	shutdown func()
 }
 
@@ -58,24 +58,37 @@ func NewSenderOTel(log Logger, opts *Options) *SenderOTel {
 		log.Fatal("unknown protocol: %s", opts.Output.Protocol)
 	}
 
-	otelshutdown, err := otelconfig.ConfigureOpenTelemetry(
-		otelconfig.WithExporterProtocol(protocol),
-		otelconfig.WithServiceName(opts.Telemetry.Dataset),
-		otelconfig.WithTracesExporterEndpoint(otelTracesFromURL(opts.apihost)),
-		otelconfig.WithTracesExporterInsecure(opts.Telemetry.Insecure),
-		otelconfig.WithMetricsEnabled(false),
-		otelconfig.WithLogLevel(opts.Global.LogLevel),
-		otelconfig.WithLogger(OtelLogger{log}),
-		otelconfig.WithHeaders(map[string]string{
-			"x-honeycomb-team": opts.Telemetry.APIKey,
-		}),
-	)
-	if err != nil {
-		log.Fatal("failure configuring otel: %v", err)
+	tracers := make(map[string]trace.Tracer)
+	var shutdownFuncs []func()
+
+	services := []string(opts.Telemetry.Services)
+	for _, service := range services {
+		shutdown, err := otelconfig.ConfigureOpenTelemetry(
+			otelconfig.WithExporterProtocol(protocol),
+			otelconfig.WithServiceName(service),
+			otelconfig.WithTracesExporterEndpoint(otelTracesFromURL(opts.apihost)),
+			otelconfig.WithTracesExporterInsecure(opts.Telemetry.Insecure),
+			otelconfig.WithMetricsEnabled(false),
+			otelconfig.WithLogLevel(opts.Global.LogLevel),
+			otelconfig.WithLogger(OtelLogger{log}),
+			otelconfig.WithHeaders(map[string]string{
+				"x-honeycomb-team": opts.Telemetry.APIKey,
+			}),
+		)
+		if err != nil {
+			log.Fatal("failure configuring otel for service %s: %v", service, err)
+		}
+		shutdownFuncs = append(shutdownFuncs, shutdown)
+		tracers[service] = otel.Tracer(ResourceLibrary, trace.WithInstrumentationVersion(ResourceVersion))
 	}
+
 	return &SenderOTel{
-		tracer:   otel.Tracer(ResourceLibrary, trace.WithInstrumentationVersion(ResourceVersion)),
-		shutdown: otelshutdown,
+		tracers: tracers,
+		shutdown: func() {
+			for _, shutdown := range shutdownFuncs {
+				shutdown()
+			}
+		},
 	}
 }
 
@@ -83,16 +96,28 @@ func (t *SenderOTel) Close() {
 	t.shutdown()
 }
 
-func (t *SenderOTel) CreateTrace(ctx context.Context, name string, fielder *Fielder, count int64) (context.Context, Sendable) {
-	ctx, root := t.tracer.Start(ctx, name)
+func (t *SenderOTel) CreateTrace(ctx context.Context, name string, service string, fielder *Fielder, count int64) (context.Context, Sendable) {
+	log := NewLogger(0)
+	log.Printf("creating trace %s for service %s.\n", name, service)
+	tracer, exists := t.tracers[service]
+	if !exists {
+		log.Fatal("service %s not found", service)
+	}
+	ctx, root := tracer.Start(ctx, name)
 	fielder.AddFields(root, count, 0)
 	var ots OTelSendable
 	ots.Span = root
 	return ctx, ots
 }
 
-func (t *SenderOTel) CreateSpan(ctx context.Context, name string, level int, fielder *Fielder) (context.Context, Sendable) {
-	ctx, span := t.tracer.Start(ctx, name)
+func (t *SenderOTel) CreateSpan(ctx context.Context, name string, service string, level int, fielder *Fielder) (context.Context, Sendable) {
+	log := NewLogger(0)
+	// log.Printf("creating span %s for service %s.\n", name, service)
+	tracer, exists := t.tracers[service]
+	if !exists {
+		log.Fatal("service %s not found", service)
+	}
+	ctx, span := tracer.Start(ctx, name)
 	if rand.Intn(10) == 0 {
 		span.AddEvent("exception", trace.WithAttributes(
 			attribute.KeyValue{Key: "exception.type", Value: attribute.StringValue("error")},

--- a/sender_otel_honey.go
+++ b/sender_otel_honey.go
@@ -98,7 +98,7 @@ func (t *SenderOTel) Close() {
 
 func (t *SenderOTel) CreateTrace(ctx context.Context, name string, service string, fielder *Fielder, count int64) (context.Context, Sendable) {
 	log := NewLogger(0)
-	log.Printf("creating trace %s for service %s.\n", name, service)
+	// log.Printf("creating trace %s for service %s.\n", name, service)
 	tracer, exists := t.tracers[service]
 	if !exists {
 		log.Fatal("service %s not found", service)

--- a/sender_print.go
+++ b/sender_print.go
@@ -40,6 +40,7 @@ func (t *traceInfo) span(parent string) *traceInfo {
 type PrintSendable struct {
 	TInfo     *traceInfo
 	Name      string
+	Service   string
 	StartTime time.Time
 	Fields    map[string]interface{}
 	log       Logger
@@ -68,7 +69,7 @@ func (t *SenderPrint) Close() {
 
 type PrintKey string
 
-func (t *SenderPrint) CreateTrace(ctx context.Context, name string, fielder *Fielder, count int64) (context.Context, Sendable) {
+func (t *SenderPrint) CreateTrace(ctx context.Context, name string, service string, fielder *Fielder, count int64) (context.Context, Sendable) {
 	t.tracecount++
 	t.nspans++
 	tinfo := &traceInfo{
@@ -79,6 +80,7 @@ func (t *SenderPrint) CreateTrace(ctx context.Context, name string, fielder *Fie
 	ctx = context.WithValue(ctx, PrintKey("trace"), tinfo)
 	return ctx, &PrintSendable{
 		Name:      name,
+		Service:   service,
 		TInfo:     tinfo,
 		StartTime: time.Now(),
 		Fields:    fielder.GetFields(count, 0),
@@ -86,12 +88,13 @@ func (t *SenderPrint) CreateTrace(ctx context.Context, name string, fielder *Fie
 	}
 }
 
-func (t *SenderPrint) CreateSpan(ctx context.Context, name string, level int, fielder *Fielder) (context.Context, Sendable) {
+func (t *SenderPrint) CreateSpan(ctx context.Context, name string, service string, level int, fielder *Fielder) (context.Context, Sendable) {
 	t.nspans++
 	tinfo := ctx.Value(PrintKey("trace")).(*traceInfo)
 	ctx = context.WithValue(ctx, PrintKey("trace"), tinfo.span(tinfo.SpanId))
 	return ctx, &PrintSendable{
 		Name:      name,
+		Service:   service,
 		TInfo:     tinfo.span(tinfo.SpanId),
 		StartTime: time.Now(),
 		Fields:    fielder.GetFields(0, level),


### PR DESCRIPTION
## Which problem is this PR solving?

- #54 

## Short description of the changes

This creates a config option for use with the otel sender to generate traces with multiple service.name resource attributes, so that traffic more closely represents a multi-service architecture.

As it exists here, the first service is used as an ingest service for the root span, and then each layer of depth goes to the next service in the array of service names.  Providing an ordered, consistent depth of services.

Would love some feedback of what's needed to bring it into main.
