### PR TITLE
feat: add option to enable transmission using msgpack

### DIFF
--- a/main.go
+++ b/main.go
@@ -42,6 +42,7 @@ type Options struct {
 	} `group:"Quantity Options"`
 	Output struct {
 		Sender             string        `long:"sender" description:"type of sender" choice:"honeycomb" choice:"otel" choice:"print" choice:"dummy" default:"honeycomb"`
+		Msgpack            bool          `long:"msgpack" description:"use this for emitting honeycomb data format using msgpack"`
 		Protocol           string        `long:"protocol" description:"for otel only, protocol to use" choice:"grpc" choice:"http" default:"grpc"`
 		MaxQueueSize       int           `long:"maxqueuesize" description:"for otel only, maximum number of spans to queue before dropping"`
 		MaxExportBatchSize int           `long:"maxexportbatchsize" description:"for otel only, maximum number of spans to export at once"`

--- a/sender_honeycomb.go
+++ b/sender_honeycomb.go
@@ -4,6 +4,8 @@ import (
 	"context"
 
 	"github.com/honeycombio/beeline-go"
+	"github.com/honeycombio/libhoney-go"
+	"github.com/honeycombio/libhoney-go/transmission"
 )
 
 type SenderHoneycomb struct{}
@@ -12,11 +14,22 @@ type SenderHoneycomb struct{}
 var _ Sender = (*SenderHoneycomb)(nil)
 
 func NewSenderHoneycomb(opts *Options) *SenderHoneycomb {
+	libhoneyClient, _ := libhoney.NewClient(libhoney.ClientConfig{
+		APIKey:  opts.Telemetry.APIKey,
+		Dataset: opts.Telemetry.Dataset,
+		APIHost: opts.apihost.String(),
+		Transmission: &transmission.Honeycomb{
+			EnableMsgpackEncoding: opts.Output.Msgpack,
+			MaxBatchSize:          uint(libhoney.DefaultMaxBatchSize),
+			BatchTimeout:          libhoney.DefaultBatchTimeout,
+		},
+	})
 	beeline.Init(beeline.Config{
 		WriteKey:    opts.Telemetry.APIKey,
 		APIHost:     opts.apihost.String(),
 		ServiceName: opts.Telemetry.Dataset,
 		Debug:       opts.DebugLevel() > 2,
+		Client:      libhoneyClient,
 	})
 	return &SenderHoneycomb{}
 }


### PR DESCRIPTION
## Which problem is this PR solving?

- Enables the honeycomb format to be emitted using msgpack instead of the default of json.

## Short description of the changes

- adds `msgpack` to the output format options and configures the transmission to use it if the option is present.

