### PR TITLE
chore: update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @honeycombio/pipeline-team
+* @honeycombio/agentic-observability


### PR DESCRIPTION
Update codeowners to the agentic-observability team.
